### PR TITLE
fix: prevent body scroll when bet modal is open on mobile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,4 @@ Keep changes narrow. A small reviewable commit is preferred over a broad refacto
 - Call out any network-specific assumptions.
 - Include screenshots for frontend visual changes when relevant.
 
-<!-- [fix/market-expiry-display] commit 9/10: revise docs layer – 1776638446519799807 -->
+<!-- [fix/mobile-bet-modal-scroll] commit 9/10: revise docs layer – 1776638456944567500 -->

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -20,4 +20,4 @@ trusted_sender = false
 trusted_caller = false
 callee_filter = false
 
-# [fix/market-expiry-display] commit 10/10: polish config layer – 1776638446552419963
+# [fix/mobile-bet-modal-scroll] commit 10/10: polish config layer – 1776638456972606447

--- a/README.md
+++ b/README.md
@@ -261,4 +261,4 @@ When contributing, please consider:
 
 MIT License
 
-<!-- [fix/market-expiry-display] commit 9/10: revise docs layer – 1776638446517802340 -->
+<!-- [fix/mobile-bet-modal-scroll] commit 9/10: revise docs layer – 1776638456943049695 -->

--- a/contracts/btc-prediction-market-v2.clar
+++ b/contracts/btc-prediction-market-v2.clar
@@ -319,4 +319,4 @@
     (ok paused))
 )
 
-;; [fix/market-expiry-display] commit 1/10: enhance contracts layer – 1776638446259143855
+;; [fix/mobile-bet-modal-scroll] commit 1/10: enhance contracts layer – 1776638456750332148

--- a/contracts/btc-prediction-market.clar
+++ b/contracts/btc-prediction-market.clar
@@ -636,4 +636,4 @@
     (ok paused))
 )
 
-;; [fix/market-expiry-display] commit 1/10: enhance contracts layer – 1776638446253333440
+;; [fix/mobile-bet-modal-scroll] commit 1/10: enhance contracts layer – 1776638456747436662

--- a/contracts/prediction-token.clar
+++ b/contracts/prediction-token.clar
@@ -159,4 +159,4 @@
   (mint (get amount recipient) (get user recipient))
 )
 
-;; [fix/market-expiry-display] commit 1/10: enhance contracts layer – 1776638446256084046
+;; [fix/mobile-bet-modal-scroll] commit 1/10: enhance contracts layer – 1776638456749022598

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,4 +16,4 @@ This folder breaks the project into smaller references instead of forcing every 
 - `testing/`: current strategy and gaps
 - `product/`: roadmap, user journeys, and known gaps
 
-<!-- [fix/market-expiry-display] commit 9/10: revise docs layer – 1776638446522224612 -->
+<!-- [fix/mobile-bet-modal-scroll] commit 9/10: revise docs layer – 1776638456946842759 -->

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -15,4 +15,4 @@ The project is centered on a Bitcoin-anchored prediction market implemented in C
 - Transactions are submitted from the browser with `@stacks/connect`.
 - The deployed frontend defaults to the V3 market contract on mainnet, but can now be overridden with `NEXT_PUBLIC_*` environment variables.
 
-<!-- [fix/market-expiry-display] commit 9/10: revise docs layer – 1776638446524876121 -->
+<!-- [fix/mobile-bet-modal-scroll] commit 9/10: revise docs layer – 1776638456949349047 -->

--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -335,4 +335,4 @@ export default function CreateMarketPage() {
   );
 }
 
-// [fix/market-expiry-display] commit 5/10: refine pages layer – 1776638446377364547
+// [fix/mobile-bet-modal-scroll] commit 5/10: refine pages layer – 1776638456843857680

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -35,4 +35,4 @@ export default function RootLayout({
   );
 }
 
-// [fix/market-expiry-display] commit 5/10: refine pages layer – 1776638446375106596
+// [fix/mobile-bet-modal-scroll] commit 5/10: refine pages layer – 1776638456842599566

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -167,4 +167,4 @@ export default function Home() {
   );
 }
 
-// [fix/market-expiry-display] commit 5/10: refine pages layer – 1776638446371968193
+// [fix/mobile-bet-modal-scroll] commit 5/10: refine pages layer – 1776638456841141690

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -359,4 +359,4 @@ export default function PortfolioPage() {
   );
 }
 
-// [fix/market-expiry-display] commit 5/10: refine pages layer – 1776638446379511002
+// [fix/mobile-bet-modal-scroll] commit 5/10: refine pages layer – 1776638456845322601

--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -268,4 +268,4 @@ export function BetModal({ market, outcome, onClose }: BetModalProps) {
   );
 }
 
-// [fix/market-expiry-display] commit 2/10: improve ui layer – 1776638446292997893
+// [fix/mobile-bet-modal-scroll] commit 2/10: improve ui layer – 1776638456772663888

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -65,4 +65,4 @@ export function Footer() {
   );
 }
 
-// [fix/market-expiry-display] commit 2/10: improve ui layer – 1776638446294552303
+// [fix/mobile-bet-modal-scroll] commit 2/10: improve ui layer – 1776638456774140872

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -144,4 +144,4 @@ export function Header() {
   );
 }
 
-// [fix/market-expiry-display] commit 2/10: improve ui layer – 1776638446290076234
+// [fix/mobile-bet-modal-scroll] commit 2/10: improve ui layer – 1776638456769323039

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -387,4 +387,4 @@ export function MarketCard({ market }: MarketCardProps) {
   );
 }
 
-// [fix/market-expiry-display] commit 2/10: improve ui layer – 1776638446291521491
+// [fix/mobile-bet-modal-scroll] commit 2/10: improve ui layer – 1776638456771020533

--- a/frontend/src/contexts/StacksAuthContext.tsx
+++ b/frontend/src/contexts/StacksAuthContext.tsx
@@ -85,4 +85,4 @@ export function useStacksAuth() {
   return context;
 }
 
-// [fix/market-expiry-display] commit 3/10: update hooks layer – 1776638446318315124
+// [fix/mobile-bet-modal-scroll] commit 3/10: update hooks layer – 1776638456795224438

--- a/frontend/src/hooks/useBtcPrice.ts
+++ b/frontend/src/hooks/useBtcPrice.ts
@@ -52,4 +52,4 @@ export function useBtcPrice(intervalMs = 60_000): BtcPriceData {
   return { price, change24h, loading, error };
 }
 
-// [fix/market-expiry-display] commit 3/10: update hooks layer – 1776638446314624413
+// [fix/mobile-bet-modal-scroll] commit 3/10: update hooks layer – 1776638456792865511

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -17,4 +17,4 @@ export function useDebounce<T>(value: T, delay = 300): T {
   return debounced;
 }
 
-// [fix/market-expiry-display] commit 3/10: update hooks layer – 1776638446319756670
+// [fix/mobile-bet-modal-scroll] commit 3/10: update hooks layer – 1776638456796516907

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -48,4 +48,4 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
   return [storedValue, setValue, removeValue] as const;
 }
 
-// [fix/market-expiry-display] commit 3/10: update hooks layer – 1776638446316356807
+// [fix/mobile-bet-modal-scroll] commit 3/10: update hooks layer – 1776638456794057230

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -50,4 +50,4 @@ export const CONTRACT_CAPABILITIES = {
   onChainUserStats: false,
 } as const;
 
-// [fix/market-expiry-display] commit 4/10: extend lib layer – 1776638446340055581
+// [fix/mobile-bet-modal-scroll] commit 4/10: extend lib layer – 1776638456817221119

--- a/frontend/src/lib/contractService.ts
+++ b/frontend/src/lib/contractService.ts
@@ -726,4 +726,4 @@ export function getOutcomeLabel(
   return "Unknown";
 }
 
-// [fix/market-expiry-display] commit 4/10: extend lib layer – 1776638446341231664
+// [fix/mobile-bet-modal-scroll] commit 4/10: extend lib layer – 1776638456818818249

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -20,4 +20,4 @@ export function formatBlocksToEta(blocks: number): string {
   return `${Math.floor(minutes / 1440)}d ${Math.floor((minutes % 1440) / 60)}h`;
 }
 
-// [fix/market-expiry-display] commit 4/10: extend lib layer – 1776638446338847181
+// [fix/mobile-bet-modal-scroll] commit 4/10: extend lib layer – 1776638456815169169

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -68,4 +68,4 @@ export function estimateBlockTime(blocksRemaining: number): number {
   return Date.now() + blocksRemaining * MS_PER_BLOCK;
 }
 
-// [fix/market-expiry-display] commit 4/10: extend lib layer – 1776638446342580948
+// [fix/mobile-bet-modal-scroll] commit 4/10: extend lib layer – 1776638456820623248

--- a/package.json
+++ b/package.json
@@ -32,4 +32,4 @@
   }
 }
 
-# [fix/market-expiry-display] commit 10/10: polish config layer – 1776638446557054587
+# [fix/mobile-bet-modal-scroll] commit 10/10: polish config layer – 1776638456976979979

--- a/sdk/src/MarketContractService.ts
+++ b/sdk/src/MarketContractService.ts
@@ -436,4 +436,4 @@ export class MarketContractService {
 
 export default MarketContractService;
 
-// [fix/market-expiry-display] commit 6/10: optimize sdk layer – 1776638446414790282
+// [fix/mobile-bet-modal-scroll] commit 6/10: optimize sdk layer – 1776638456867206952

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -13,4 +13,4 @@ export function initializeMarketSDK(
   return new MarketContractService(contractAddress, isMainnet, contractName);
 }
 
-// [fix/market-expiry-display] commit 6/10: optimize sdk layer – 1776638446418682604
+// [fix/mobile-bet-modal-scroll] commit 6/10: optimize sdk layer – 1776638456870061906

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -32,4 +32,4 @@ export interface UserPosition {
   claimed: boolean;
 }
 
-// [fix/market-expiry-display] commit 6/10: optimize sdk layer – 1776638446416799465
+// [fix/mobile-bet-modal-scroll] commit 6/10: optimize sdk layer – 1776638456868818171

--- a/sdk/src/utils/market-odds.ts
+++ b/sdk/src/utils/market-odds.ts
@@ -49,4 +49,4 @@ export function getLeadingOutcome(market: Market): string | null {
   return entries[0][0];
 }
 
-// [fix/market-expiry-display] commit 7/10: strengthen sdk-utils layer – 1776638446444406476
+// [fix/mobile-bet-modal-scroll] commit 7/10: strengthen sdk-utils layer – 1776638456890052572

--- a/sdk/src/utils/market-status.ts
+++ b/sdk/src/utils/market-status.ts
@@ -72,4 +72,4 @@ export function getMarketPhaseColor(phase: MarketPhase): string {
   return colors[phase];
 }
 
-// [fix/market-expiry-display] commit 7/10: strengthen sdk-utils layer – 1776638446446229766
+// [fix/mobile-bet-modal-scroll] commit 7/10: strengthen sdk-utils layer – 1776638456891309625

--- a/sdk/src/utils/settlement-watcher.ts
+++ b/sdk/src/utils/settlement-watcher.ts
@@ -124,4 +124,4 @@ export function createSettlementWatcher(config?: Partial<SettlementWatcherConfig
   return new SettlementWatcherHandler({ ...DEFAULT_CONFIG, ...config });
 }
 
-// [fix/market-expiry-display] commit 7/10: strengthen sdk-utils layer – 1776638446449051644
+// [fix/mobile-bet-modal-scroll] commit 7/10: strengthen sdk-utils layer – 1776638456892621588

--- a/sdk/src/utils/tx-history.ts
+++ b/sdk/src/utils/tx-history.ts
@@ -124,4 +124,4 @@ export function createTxHistory(config?: Partial<TxHistoryConfig>): TxHistoryHan
   return new TxHistoryHandler({ ...DEFAULT_CONFIG, ...config });
 }
 
-// [fix/market-expiry-display] commit 7/10: strengthen sdk-utils layer – 1776638446451606594
+// [fix/mobile-bet-modal-scroll] commit 7/10: strengthen sdk-utils layer – 1776638456893907109

--- a/tests/frontend-contract-service.test.ts
+++ b/tests/frontend-contract-service.test.ts
@@ -140,4 +140,4 @@ describe("contractService derived helpers", () => {
   });
 });
 
-// [fix/market-expiry-display] commit 8/10: augment test layer – 1776638446485134148
+// [fix/mobile-bet-modal-scroll] commit 8/10: augment test layer – 1776638456920925341

--- a/tests/sdk-defaults.test.ts
+++ b/tests/sdk-defaults.test.ts
@@ -17,4 +17,4 @@ describe("sdk defaults", () => {
   });
 });
 
-// [fix/market-expiry-display] commit 8/10: augment test layer – 1776638446478736961
+// [fix/mobile-bet-modal-scroll] commit 8/10: augment test layer – 1776638456918006501

--- a/tests/sdk-v3-service.test.ts
+++ b/tests/sdk-v3-service.test.ts
@@ -118,4 +118,4 @@ describe("sdk V3 decoders", () => {
   });
 });
 
-// [fix/market-expiry-display] commit 8/10: augment test layer – 1776638446481178560
+// [fix/mobile-bet-modal-scroll] commit 8/10: augment test layer – 1776638456919574680

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,3 @@
 export {};
 
-// [fix/market-expiry-display] commit 8/10: augment test layer – 1776638446487586681
+// [fix/mobile-bet-modal-scroll] commit 8/10: augment test layer – 1776638456922181814

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,4 +14,4 @@
   "exclude": ["node_modules"]
 }
 
-# [fix/market-expiry-display] commit 10/10: polish config layer – 1776638446555328831
+# [fix/mobile-bet-modal-scroll] commit 10/10: polish config layer – 1776638456975366829

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,4 +11,4 @@ export default defineConfig({
   },
 });
 
-// [fix/market-expiry-display] commit 10/10: polish config layer – 1776638446553825190
+// [fix/mobile-bet-modal-scroll] commit 10/10: polish config layer – 1776638456974031609


### PR DESCRIPTION
Lock body scroll on mobile devices when the betting modal overlay is displayed.