### PR TITLE
feat: ops toolkit update PR 29

### DIFF
--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -1,0 +1,9 @@
+# Ops Automation PR 29
+
+This PR introduces ten reusable operational utilities for batch betting, reporting, and retry planning.
+
+## Commit 1/10: normalize-wallet-rows
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -13,3 +13,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 3/10: compute-fee-aware-budget
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -37,3 +37,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 7/10: summarize-failures
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -19,3 +19,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 4/10: format-broadcast-report
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -49,3 +49,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 9/10: map-wallet-health
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -43,3 +43,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 8/10: estimate-settlement-window
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -31,3 +31,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 6/10: derive-outcome-plan
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -55,3 +55,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 10/10: render-ops-checklist
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -7,3 +7,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 2/10: group-bets-by-outcome
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/docs/operations/ops-automation/pr-29.md
+++ b/docs/operations/ops-automation/pr-29.md
@@ -25,3 +25,9 @@ This PR introduces ten reusable operational utilities for batch betting, reporti
 - Adds \ utility under \.
 - Adds unit test coverage under \.
 - Keeps utility scoped for PR-specific operational workflows.
+
+## Commit 5/10: build-retry-candidates
+
+- Adds \ utility under \.
+- Adds unit test coverage under \.
+- Keeps utility scoped for PR-specific operational workflows.

--- a/tests/unit/ops-automation/pr-29/build-retry-candidates.test.ts
+++ b/tests/unit/ops-automation/pr-29/build-retry-candidates.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { buildRetryCandidates } from '../../../../tools/ops-automation/pr-29/build-retry-candidates';
+
+describe('buildRetryCandidates', () => {
+  it('keeps only failed entries for retry', () => {
+    const result = buildRetryCandidates([{ status: 'ok' }, { status: 'failed' }, { status: 'failed' }]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/compute-fee-aware-budget.test.ts
+++ b/tests/unit/ops-automation/pr-29/compute-fee-aware-budget.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { computeFeeAwareBudget } from '../../../../tools/ops-automation/pr-29/compute-fee-aware-budget';
+
+describe('computeFeeAwareBudget', () => {
+  it('reserves tx fee from wallet budget', () => {
+    expect(computeFeeAwareBudget(50000, 10000)).toBe(40000);
+    expect(computeFeeAwareBudget(5000, 10000)).toBe(0);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/derive-outcome-plan.test.ts
+++ b/tests/unit/ops-automation/pr-29/derive-outcome-plan.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { deriveOutcomePlan } from '../../../../tools/ops-automation/pr-29/derive-outcome-plan';
+
+describe('deriveOutcomePlan', () => {
+  it('alternates outcome-a and outcome-b', () => {
+    expect(deriveOutcomePlan(4)).toEqual(['outcome-a', 'outcome-b', 'outcome-a', 'outcome-b']);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/estimate-settlement-window.test.ts
+++ b/tests/unit/ops-automation/pr-29/estimate-settlement-window.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { estimateSettlementWindow } from '../../../../tools/ops-automation/pr-29/estimate-settlement-window';
+
+describe('estimateSettlementWindow', () => {
+  it('adds confirmation depth to settlement block', () => {
+    expect(estimateSettlementWindow(1000)).toBe(1006);
+    expect(estimateSettlementWindow(1000, 12)).toBe(1012);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/format-broadcast-report.test.ts
+++ b/tests/unit/ops-automation/pr-29/format-broadcast-report.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { formatBroadcastReport } from '../../../../tools/ops-automation/pr-29/format-broadcast-report';
+
+describe('formatBroadcastReport', () => {
+  it('renders ordered tx report lines', () => {
+    const output = formatBroadcastReport(['abc', 'def']);
+    expect(output).toContain('1. abc');
+    expect(output).toContain('2. def');
+  });
+});

--- a/tests/unit/ops-automation/pr-29/group-bets-by-outcome.test.ts
+++ b/tests/unit/ops-automation/pr-29/group-bets-by-outcome.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { groupBetsByOutcome } from '../../../../tools/ops-automation/pr-29/group-bets-by-outcome';
+
+describe('groupBetsByOutcome', () => {
+  it('aggregates totals by outcome', () => {
+    const grouped = groupBetsByOutcome([
+      { outcome: 'outcome-a', amount: 10000 },
+      { outcome: 'outcome-b', amount: 15000 },
+      { outcome: 'outcome-a', amount: 5000 },
+    ]);
+    expect(grouped['outcome-a']).toBe(15000);
+    expect(grouped['outcome-b']).toBe(15000);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/map-wallet-health.test.ts
+++ b/tests/unit/ops-automation/pr-29/map-wallet-health.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { mapWalletHealth } from '../../../../tools/ops-automation/pr-29/map-wallet-health';
+
+describe('mapWalletHealth', () => {
+  it('marks wallets as healthy based on balance threshold', () => {
+    const result = mapWalletHealth([
+      { address: 'A', balance: 30000, minRequired: 20000 },
+      { address: 'B', balance: 10000, minRequired: 20000 },
+    ]);
+    expect(result[0].healthy).toBe(true);
+    expect(result[1].healthy).toBe(false);
+  });
+});

--- a/tests/unit/ops-automation/pr-29/normalize-wallet-rows.test.ts
+++ b/tests/unit/ops-automation/pr-29/normalize-wallet-rows.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWalletRows } from '../../../../tools/ops-automation/pr-29/normalize-wallet-rows';
+
+describe('normalizeWalletRows', () => {
+  it('normalizes and filters raw rows', () => {
+    const rows = [{ address: ' sp123 ', privateKey: ' key ', name: '  first ' }, { name: 'no-address' }];
+    const result = normalizeWalletRows(rows as Array<Record<string, string>>);
+    expect(result).toHaveLength(1);
+    expect(result[0].address).toBe('SP123');
+    expect(result[0].name).toBe('first');
+  });
+});

--- a/tests/unit/ops-automation/pr-29/render-ops-checklist.test.ts
+++ b/tests/unit/ops-automation/pr-29/render-ops-checklist.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { renderOpsChecklist } from '../../../../tools/ops-automation/pr-29/render-ops-checklist';
+
+describe('renderOpsChecklist', () => {
+  it('renders markdown checklist lines', () => {
+    const out = renderOpsChecklist(['fund wallets', 'place bets']);
+    expect(out).toContain('- [ ] fund wallets');
+    expect(out).toContain('- [ ] place bets');
+  });
+});

--- a/tests/unit/ops-automation/pr-29/summarize-failures.test.ts
+++ b/tests/unit/ops-automation/pr-29/summarize-failures.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeFailures } from '../../../../tools/ops-automation/pr-29/summarize-failures';
+
+describe('summarizeFailures', () => {
+  it('categorizes rate-limit and other failures', () => {
+    const summary = summarizeFailures(['rate limit exceeded', 'timeout', 'rate limit exceeded']);
+    expect(summary['rate-limit']).toBe(2);
+    expect(summary.other).toBe(1);
+  });
+});

--- a/tools/ops-automation/pr-29/build-retry-candidates.ts
+++ b/tools/ops-automation/pr-29/build-retry-candidates.ts
@@ -1,0 +1,3 @@
+export function buildRetryCandidates<T extends { status: 'ok' | 'failed' }>(items: T[]): T[] {
+  return items.filter((item) => item.status === 'failed');
+}

--- a/tools/ops-automation/pr-29/compute-fee-aware-budget.ts
+++ b/tools/ops-automation/pr-29/compute-fee-aware-budget.ts
@@ -1,0 +1,4 @@
+export function computeFeeAwareBudget(balanceMicroStx: number, feeMicroStx: number): number {
+  if (balanceMicroStx <= feeMicroStx) return 0;
+  return balanceMicroStx - feeMicroStx;
+}

--- a/tools/ops-automation/pr-29/derive-outcome-plan.ts
+++ b/tools/ops-automation/pr-29/derive-outcome-plan.ts
@@ -1,0 +1,5 @@
+import type { Outcome } from './index';
+
+export function deriveOutcomePlan(size: number): Outcome[] {
+  return Array.from({ length: size }, (_, i) => (i % 2 === 0 ? 'outcome-a' : 'outcome-b'));
+}

--- a/tools/ops-automation/pr-29/estimate-settlement-window.ts
+++ b/tools/ops-automation/pr-29/estimate-settlement-window.ts
@@ -1,0 +1,3 @@
+export function estimateSettlementWindow(settlementBlock: number, confirmationDepth = 6): number {
+  return settlementBlock + confirmationDepth;
+}

--- a/tools/ops-automation/pr-29/format-broadcast-report.ts
+++ b/tools/ops-automation/pr-29/format-broadcast-report.ts
@@ -1,0 +1,4 @@
+export function formatBroadcastReport(txids: string[]): string {
+  if (txids.length === 0) return 'No transactions broadcast.';
+  return txids.map((txid, idx) => `${idx + 1}. ${txid}`).join('\n');
+}

--- a/tools/ops-automation/pr-29/group-bets-by-outcome.ts
+++ b/tools/ops-automation/pr-29/group-bets-by-outcome.ts
@@ -1,0 +1,11 @@
+import type { Outcome } from './index';
+
+export function groupBetsByOutcome(entries: Array<{ outcome: Outcome; amount: number }>): Record<Outcome, number> {
+  return entries.reduce(
+    (acc, entry) => {
+      acc[entry.outcome] += entry.amount;
+      return acc;
+    },
+    { 'outcome-a': 0, 'outcome-b': 0 } as Record<Outcome, number>
+  );
+}

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -13,3 +13,4 @@ export * from './build-retry-candidates';
 export * from './derive-outcome-plan';
 export * from './summarize-failures';
 export * from './estimate-settlement-window';
+export * from './map-wallet-health';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -14,3 +14,4 @@ export * from './derive-outcome-plan';
 export * from './summarize-failures';
 export * from './estimate-settlement-window';
 export * from './map-wallet-health';
+export * from './render-ops-checklist';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -8,3 +8,4 @@ export type Outcome = 'outcome-a' | 'outcome-b';
 export * from './normalize-wallet-rows';
 export * from './group-bets-by-outcome';
 export * from './compute-fee-aware-budget';
+export * from './format-broadcast-report';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -10,3 +10,4 @@ export * from './group-bets-by-outcome';
 export * from './compute-fee-aware-budget';
 export * from './format-broadcast-report';
 export * from './build-retry-candidates';
+export * from './derive-outcome-plan';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -11,3 +11,4 @@ export * from './compute-fee-aware-budget';
 export * from './format-broadcast-report';
 export * from './build-retry-candidates';
 export * from './derive-outcome-plan';
+export * from './summarize-failures';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -6,3 +6,4 @@ export type WalletRow = {
 
 export type Outcome = 'outcome-a' | 'outcome-b';
 export * from './normalize-wallet-rows';
+export * from './group-bets-by-outcome';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -1,0 +1,8 @@
+export type WalletRow = {
+  address: string;
+  privateKey?: string;
+  name?: string;
+};
+
+export type Outcome = 'outcome-a' | 'outcome-b';
+export * from './normalize-wallet-rows';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -7,3 +7,4 @@ export type WalletRow = {
 export type Outcome = 'outcome-a' | 'outcome-b';
 export * from './normalize-wallet-rows';
 export * from './group-bets-by-outcome';
+export * from './compute-fee-aware-budget';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -12,3 +12,4 @@ export * from './format-broadcast-report';
 export * from './build-retry-candidates';
 export * from './derive-outcome-plan';
 export * from './summarize-failures';
+export * from './estimate-settlement-window';

--- a/tools/ops-automation/pr-29/index.ts
+++ b/tools/ops-automation/pr-29/index.ts
@@ -9,3 +9,4 @@ export * from './normalize-wallet-rows';
 export * from './group-bets-by-outcome';
 export * from './compute-fee-aware-budget';
 export * from './format-broadcast-report';
+export * from './build-retry-candidates';

--- a/tools/ops-automation/pr-29/map-wallet-health.ts
+++ b/tools/ops-automation/pr-29/map-wallet-health.ts
@@ -1,0 +1,9 @@
+export type WalletHealth = {
+  address: string;
+  balance: number;
+  minRequired: number;
+};
+
+export function mapWalletHealth(items: WalletHealth[]): Array<WalletHealth & { healthy: boolean }> {
+  return items.map((item) => ({ ...item, healthy: item.balance >= item.minRequired }));
+}

--- a/tools/ops-automation/pr-29/normalize-wallet-rows.ts
+++ b/tools/ops-automation/pr-29/normalize-wallet-rows.ts
@@ -1,0 +1,11 @@
+import type { WalletRow } from './index';
+
+export function normalizeWalletRows(rows: Array<Record<string, string>>): WalletRow[] {
+  return rows
+    .filter((row) => !!row.address)
+    .map((row, idx) => ({
+      address: row.address.trim().toUpperCase(),
+      privateKey: row.privateKey?.trim(),
+      name: row.name?.trim() || `Wallet ${String(idx + 1).padStart(3, '0')}`,
+    }));
+}

--- a/tools/ops-automation/pr-29/render-ops-checklist.ts
+++ b/tools/ops-automation/pr-29/render-ops-checklist.ts
@@ -1,0 +1,3 @@
+export function renderOpsChecklist(items: string[]): string {
+  return items.map((item) => `- [ ] ${item}`).join('\n');
+}

--- a/tools/ops-automation/pr-29/summarize-failures.ts
+++ b/tools/ops-automation/pr-29/summarize-failures.ts
@@ -1,0 +1,7 @@
+export function summarizeFailures(messages: string[]): Record<string, number> {
+  return messages.reduce<Record<string, number>>((acc, message) => {
+    const key = message.includes('rate limit') ? 'rate-limit' : 'other';
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
## Summary
- adds 10 operational utilities for prediction-market workflows
- includes unit tests for each utility
- documents each commit artifact under docs/operations/ops-toolkit

## Validation
- utilities are pure functions with deterministic tests