### PR TITLE
Docs: add market ops note 04

### DIFF
--- a/docs/market-ops/pr-04/checklist.md
+++ b/docs/market-ops/pr-04/checklist.md
@@ -1,0 +1,8 @@
+# Market Ops Checklist 04
+
+Use this checklist when preparing a small prediction-market update.
+
+- Confirm the intended network and contract version.
+- Check whether the change affects market creation, settlement, or read-only views.
+- Run the narrowest relevant verification before opening review.
+- Note any wallet, fee, or nonce assumptions in the PR body.

--- a/docs/market-ops/pr-04/overview.md
+++ b/docs/market-ops/pr-04/overview.md
@@ -1,0 +1,13 @@
+# Market Ops Note 04
+
+This note captures a small operator-facing reminder for the BTC prediction market workflow.
+
+## Purpose
+
+Keep contributors aligned on the expected market review path before contract, frontend, or automation changes are shipped.
+
+## Scope
+
+- Review market inputs before transaction construction.
+- Keep settlement assumptions explicit.
+- Prefer small, reviewable changes when updating operational tooling.

--- a/docs/market-ops/pr-04/review-notes.md
+++ b/docs/market-ops/pr-04/review-notes.md
@@ -1,0 +1,13 @@
+# Market Ops Review Notes 04
+
+These notes are intentionally short so they can sit beside small PRs without slowing review.
+
+## Reviewer Prompts
+
+- Does the change preserve the existing contract surface?
+- Are any frontend labels still consistent with the contract behavior?
+- Is the operational rollback path obvious from the changed files?
+
+## Follow-up
+
+If a change touches settlement behavior, add a focused test or document why manual verification is enough.


### PR DESCRIPTION
## Summary
- add a compact market ops overview
- add a small checklist for prediction-market updates
- add reviewer prompts for operational PRs

## Verification
- docs-only change