### PR TITLE
Docs: add market ops note 36

### DIFF
--- a/docs/market-ops/pr-36/checklist.md
+++ b/docs/market-ops/pr-36/checklist.md
@@ -1,0 +1,7 @@
+# Market Ops Checklist 36
+
+Use this checklist before finalizing the deployment checklist for iteration 36:
+- [ ] Confirm node connectivity to stacks API.
+- [ ] Check oracle public keys and signatures.
+- [ ] Run typescript type verification tools.
+- [ ] Validate standard tx fee rates.

--- a/docs/market-ops/pr-36/guidelines.md
+++ b/docs/market-ops/pr-36/guidelines.md
@@ -1,0 +1,6 @@
+# Market Ops Guidelines 36
+
+Review Guidelines for operators in iteration 36:
+- Do not exceed the transaction fee cap of 20 STX.
+- Coordinate with oracle providers to align on feed updates.
+- Check contract storage layout stability.

--- a/docs/market-ops/pr-36/overview.md
+++ b/docs/market-ops/pr-36/overview.md
@@ -1,0 +1,6 @@
+# Market Ops Overview 36
+
+This document details the operational overview for prediction market iteration 36.
+- Scope of validation: contract endpoints, oracle responses, read views.
+- Network Target: mainnet-v4
+- Safety Limits: maximum exposure 5000 STX.

--- a/docs/market-ops/pr-36/review-notes.md
+++ b/docs/market-ops/pr-36/review-notes.md
@@ -1,0 +1,6 @@
+# Market Ops Review Notes 36
+
+Operator feedback and review notes for iteration 36:
+- Ensure that the tx sender address is funded with sufficient STX for fees.
+- Note any changes in fee structure or contract signature.
+- Verify read-only functions are returning expected types.

--- a/docs/market-ops/pr-36/summary.md
+++ b/docs/market-ops/pr-36/summary.md
@@ -1,0 +1,6 @@
+# Market Ops Summary 36
+
+Summary of status checks and configurations for iteration 36:
+- Version: v2-ops-36
+- Status: Checked
+- Date of generation: 2026-05-25


### PR DESCRIPTION
This PR adds operational documentation (overview, checklist, review notes, guidelines, and summary) for iteration 36.