### PR TITLE
feat(ui): add skip navigation, ARIA landmarks, and improved focus indicators

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -107,9 +107,9 @@ body::after {
 
 /* ── Focus ring ── */
 :focus-visible {
-  outline: 2px solid var(--accent-sky);
-  outline-offset: 2px;
-  border-radius: 6px;
+  outline: 2px solid var(--accent-gold);
+  outline-offset: 3px;
+  border-radius: 8px;
 }
 
 /* ── Reduced Motion ── */
@@ -189,8 +189,15 @@ main {
   input:focus-visible,
   textarea:focus-visible,
   select:focus-visible {
-    outline: 2px solid rgba(255, 211, 105, 0.78);
+    outline: 2px solid var(--accent-gold);
     outline-offset: 3px;
+    box-shadow: 0 0 0 4px rgba(255, 211, 105, 0.15);
+  }
+
+  .input:focus-within,
+  .select:focus-within {
+    border-color: rgba(255, 211, 105, 0.5);
+    box-shadow: 0 0 0 3px rgba(255, 211, 105, 0.12);
   }
 
   input::-webkit-outer-spin-button,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -201,6 +201,16 @@ main {
 }
 
 @layer components {
+  .skip-to-content {
+    @apply fixed left-4 top-4 z-[100] -translate-y-full rounded-xl px-5 py-3 text-sm font-semibold transition-transform duration-200;
+    color: var(--bg-void);
+    background: linear-gradient(135deg, var(--accent-sun), var(--accent-gold));
+    box-shadow: 0 8px 24px rgba(255, 191, 60, 0.3);
+  }
+
+  .skip-to-content:focus {
+    transform: translateY(0);
+  }
   .app-shell {
     @apply mx-auto w-full max-w-7xl px-4 pb-20 pt-8 sm:px-6 lg:px-8;
   }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -22,10 +22,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased" suppressHydrationWarning>
+        <a href="#main-content" className="skip-to-content">Skip to main content</a>
         <ExtensionErrorSuppressor />
         <Providers>
           <Header />
-          <main className="app-shell">
+          <main id="main-content" className="app-shell">
             {children}
             <Footer />
           </main>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -11,7 +11,7 @@ const footerLinks = [
 
 export function Footer() {
   return (
-    <footer className="relative mt-12">
+    <footer role="contentinfo" aria-label="Site footer" className="relative mt-12">
       <div className="card overflow-hidden px-6 py-8 sm:px-8">
         <div className="spotlight-orb -left-12 top-0 h-32 w-32 bg-amber-300/15" />
         <div className="spotlight-orb bottom-0 right-0 h-36 w-36 bg-sky-300/15" />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -31,7 +31,7 @@ export function Header() {
       : "rounded-full border border-transparent px-4 py-2 text-slate-300 transition hover:border-white/10 hover:bg-white/8 hover:text-white";
 
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-slate-950/40 backdrop-blur-xl">
+    <header role="banner" aria-label="Main navigation" className="sticky top-0 z-50 border-b border-white/10 bg-slate-950/40 backdrop-blur-xl">
       <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-3">
           <Link href="/" className="flex items-center gap-3">
@@ -53,7 +53,7 @@ export function Header() {
           </Link>
         </div>
 
-        <nav className="hidden items-center gap-2 lg:flex">
+        <nav aria-label="Primary" className="hidden items-center gap-2 lg:flex">
           {navItems.map((item) => (
             <Link
               key={item.href}
@@ -109,7 +109,7 @@ export function Header() {
             <Dot className="h-5 w-5 text-emerald-300" />
             Design refresh live on {NETWORK_NAME}
           </div>
-          <nav className="flex flex-col gap-2">
+          <nav aria-label="Mobile navigation" className="flex flex-col gap-2">
             {navItems.map((item) => (
               <Link
                 key={item.href}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,6 +25,16 @@ export function Header() {
     setMobileMenuOpen(false);
   }, [pathname]);
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && mobileMenuOpen) {
+        setMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [mobileMenuOpen]);
+
   const navClassName = (href: string) =>
     pathname === href
       ? "rounded-full border border-amber-300/20 bg-gradient-to-r from-amber-300/90 to-cyan-300/90 px-4 py-2 text-slate-950 shadow-lg shadow-amber-500/10"
@@ -94,6 +104,7 @@ export function Header() {
           className="rounded-2xl border border-white/10 bg-white/6 p-3 text-white md:hidden"
           onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
           aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+          aria-expanded={mobileMenuOpen}
         >
           {mobileMenuOpen ? (
             <X className="h-5 w-5" />
@@ -104,7 +115,7 @@ export function Header() {
       </div>
 
       {mobileMenuOpen && (
-        <div className="mx-4 mb-4 rounded-[1.75rem] border border-white/10 bg-slate-950/85 p-4 shadow-2xl shadow-slate-950/30 md:hidden">
+        <div role="dialog" aria-modal="true" aria-label="Navigation menu" className="mx-4 mb-4 rounded-[1.75rem] border border-white/10 bg-slate-950/85 p-4 shadow-2xl shadow-slate-950/30 md:hidden">
           <div className="glass-strip mb-3 text-sm text-slate-200">
             <Dot className="h-5 w-5 text-emerald-300" />
             Design refresh live on {NETWORK_NAME}

--- a/frontend/src/components/MarketList.tsx
+++ b/frontend/src/components/MarketList.tsx
@@ -140,20 +140,21 @@ export function MarketList({ showSettled = false }: MarketListProps) {
       <div className="card">
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-slate-300">Browse and refine the current market set</p>
-          <span className="pill border border-white/10 bg-white/6 text-slate-200">
-            {visibleMarkets.length} results
+          <span className="pill border border-white/10 bg-white/6 text-slate-200" aria-live="polite" aria-atomic="true">
+            {visibleMarkets.length} {visibleMarkets.length === 1 ? 'result' : 'results'}
           </span>
         </div>
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_auto]">
           <div>
             <label className="mb-2 block text-sm text-slate-300">Search markets</label>
-            <div className="relative">
+            <div className="relative" role="search">
               <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 className="input pl-11"
                 placeholder="Search by market question or description"
+                aria-label="Search markets"
               />
               {query ? (
                 <button


### PR DESCRIPTION
Improves keyboard accessibility across the frontend:
- Skip-to-content link for keyboard users
- Enhanced focus-visible ring contrast
- ARIA landmarks on Header, Footer, and main content
- aria-live region for dynamic market count
- Keyboard-navigable mobile menu with ESC-to-close