### PR TITLE
feat: opt-in sleek Aurora theme + theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 .next/
 frontend/.next/
 .vercel/
+*.tsbuildinfo
 
 # ───────────────────────────────────────────────
 # Environment files — NEVER commit

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -532,3 +532,145 @@ main {
     border-width: 2px;
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════
+   Aurora theme — opt-in sleek variant
+   Activated via <html data-theme="aurora"> (see ThemeProvider). Only
+   overrides variables and adds interaction flourishes; the base design
+   system and the default "studio" look are left untouched.
+   ════════════════════════════════════════════════════════════════════ */
+
+[data-theme="aurora"] {
+  color-scheme: dark;
+  --bg-void: #05030f;
+  --bg-night: #0b0820;
+  --bg-deep: #110a2e;
+  --surface: rgba(20, 14, 48, 0.72);
+  --surface-strong: rgba(24, 16, 60, 0.86);
+  --surface-elevated: rgba(30, 20, 76, 0.9);
+  --surface-soft: rgba(255, 255, 255, 0.07);
+  --surface-frost: rgba(255, 255, 255, 0.04);
+  --border: rgba(167, 139, 250, 0.22);
+  --border-strong: rgba(255, 255, 255, 0.18);
+  --text-main: #f6f3ff;
+  --text-muted: #c9bdf2;
+  --text-soft: #a99fd4;
+  --text-subtle: #8479b0;
+  --accent-sun: #ffc46b;
+  --accent-gold: #ffd98a;
+  --accent-coral: #ff8fa3;
+  --accent-sky: #7ad7ff;
+  --accent-mint: #7bf7d4;
+  --accent-lime: #c6ff7a;
+  --accent-violet: #b69bff;
+  --accent-rose: #ff7ec0;
+  --shadow-soft: 0 30px 90px rgba(10, 4, 30, 0.5);
+  --shadow-glow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 28px 80px rgba(8, 3, 26, 0.55);
+  --shadow-intense: 0 48px 120px rgba(5, 2, 18, 0.62);
+}
+
+/* Animated aurora wash behind the page (Aurora theme only) */
+[data-theme="aurora"] body::after {
+  background:
+    radial-gradient(circle at 16% 20%, rgba(167, 139, 250, 0.30), transparent 20%),
+    radial-gradient(circle at 74% 22%, rgba(255, 126, 192, 0.24), transparent 20%),
+    radial-gradient(circle at 64% 76%, rgba(122, 215, 255, 0.22), transparent 26%),
+    radial-gradient(circle at 28% 74%, rgba(123, 247, 212, 0.20), transparent 22%);
+  filter: blur(48px);
+  opacity: 1;
+  animation: drift 22s ease-in-out infinite alternate;
+}
+
+[data-theme="aurora"] ::selection {
+  background: rgba(182, 155, 255, 0.38);
+  color: var(--text-main);
+}
+
+[data-theme="aurora"] *::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(182, 155, 255, 0.7), rgba(122, 215, 255, 0.7));
+  background-clip: padding-box;
+}
+
+[data-theme="aurora"] :focus-visible {
+  outline-color: var(--accent-violet);
+}
+
+/* ── Sleek micro-interactions (Aurora only) ── */
+
+/* Card hover lift + soft glow */
+[data-theme="aurora"] .card,
+[data-theme="aurora"] .panel-soft,
+[data-theme="aurora"] .panel-highlight {
+  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+[data-theme="aurora"] .card:hover,
+[data-theme="aurora"] .panel-soft:hover,
+[data-theme="aurora"] .panel-highlight:hover {
+  transform: translateY(-3px);
+  border-color: rgba(182, 155, 255, 0.4);
+  box-shadow: 0 0 0 1px rgba(182, 155, 255, 0.16),
+              0 28px 70px rgba(10, 4, 30, 0.55);
+}
+
+/* Primary button sheen sweep on hover */
+[data-theme="aurora"] .btn-primary {
+  background-size: 200% 100%;
+  background-position: 0% 0%;
+  transition: background-position 0.5s ease, box-shadow 0.25s ease, transform 0.15s ease;
+}
+
+[data-theme="aurora"] .btn-primary:hover {
+  background-position: 100% 0%;
+  box-shadow: 0 12px 30px rgba(182, 155, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+[data-theme="aurora"] .btn-primary:active {
+  transform: translateY(0);
+}
+
+/* Secondary button subtle border glow */
+[data-theme="aurora"] .btn-secondary {
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.15s ease;
+}
+
+[data-theme="aurora"] .btn-secondary:hover {
+  border-color: rgba(122, 215, 255, 0.45);
+  transform: translateY(-1px);
+}
+
+/* Shimmer flourish for loading skeletons (the .skeleton-shimmer class is
+   used by Skeleton.tsx but unstyled by default, so this only enhances
+   the Aurora experience without altering the default look). */
+@keyframes aurora-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+[data-theme="aurora"] .skeleton-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(182, 155, 255, 0.16) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: aurora-shimmer 1.6s ease-in-out infinite;
+}
+
+/* Respect reduced motion: disable the flourishes */
+@media (prefers-reduced-motion: reduce) {
+  [data-theme="aurora"] body::after,
+  [data-theme="aurora"] .skeleton-shimmer {
+    animation: none;
+  }
+  [data-theme="aurora"] .card:hover,
+  [data-theme="aurora"] .panel-soft:hover,
+  [data-theme="aurora"] .panel-highlight:hover,
+  [data-theme="aurora"] .btn-primary:hover,
+  [data-theme="aurora"] .btn-secondary:hover {
+    transform: none;
+  }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -660,10 +660,47 @@ main {
   animation: aurora-shimmer 1.6s ease-in-out infinite;
 }
 
+/* ── Aurora "cool theme" flourishes (opt-in, no markup changes) ── */
+
+/* Gradient headline text in the hero + section titles */
+[data-theme="aurora"] .hero-panel h1,
+[data-theme="aurora"] .section-title {
+  background: linear-gradient(120deg, var(--accent-gold), var(--accent-violet) 45%, var(--accent-sky));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+/* Eyebrow accent tint */
+[data-theme="aurora"] .eyebrow {
+  color: var(--accent-violet);
+}
+
+/* Hero panel: animated aurora border glow */
+[data-theme="aurora"] .hero-panel {
+  position: relative;
+  border-color: rgba(182, 155, 255, 0.28);
+  animation: aurora-glow 8s ease-in-out infinite;
+}
+
+[data-theme="aurora"] .hero-panel::before {
+  background: linear-gradient(120deg, rgba(255, 217, 138, 0.18), rgba(182, 155, 255, 0.18), rgba(122, 215, 255, 0.18));
+  opacity: 0.9;
+  animation: drift 24s ease-in-out infinite alternate;
+}
+
+@keyframes aurora-glow {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(182, 155, 255, 0.10), 0 30px 90px rgba(10, 4, 30, 0.5); }
+  50% { box-shadow: 0 0 0 1px rgba(182, 155, 255, 0.22), 0 30px 90px rgba(10, 4, 30, 0.55); }
+}
+
 /* Respect reduced motion: disable the flourishes */
 @media (prefers-reduced-motion: reduce) {
   [data-theme="aurora"] body::after,
-  [data-theme="aurora"] .skeleton-shimmer {
+  [data-theme="aurora"] .skeleton-shimmer,
+  [data-theme="aurora"] .hero-panel,
+  [data-theme="aurora"] .hero-panel::before {
     animation: none;
   }
   [data-theme="aurora"] .card:hover,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -21,6 +21,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Apply the saved theme before first paint to avoid a flash. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem('btc-pm-theme');if(t==='aurora'){document.documentElement.dataset.theme='aurora';}}catch(e){}`,
+          }}
+        />
+      </head>
       <body className="antialiased" suppressHydrationWarning>
         <a href="#main-content" className="skip-to-content">Skip to main content</a>
         <ExtensionErrorSuppressor />

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -3,13 +3,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, ReactNode } from "react";
 import { StacksAuthProvider } from "@/contexts/StacksAuthContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <StacksAuthProvider>{children}</StacksAuthProvider>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <StacksAuthProvider>{children}</StacksAuthProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { LiveNowPill } from "./LiveNowPill";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   const { isConnected, stxAddress, connect, disconnect } = useStacksAuth();
@@ -84,6 +85,7 @@ export function Header() {
               Design refresh live
             </div>
           </div>
+          <ThemeToggle />
           {isConnected ? (
             <div className="flex items-center gap-3 rounded-full border border-sky-300/15 bg-white/6 p-1.5 pl-4 shadow-lg shadow-slate-950/10">
               <span className="text-sm text-slate-300">
@@ -133,6 +135,9 @@ export function Header() {
               </Link>
             ))}
             <div className="mt-3 border-t border-white/10 pt-3">
+              <div className="mb-3">
+                <ThemeToggle />
+              </div>
               {isConnected ? (
                 <div className="flex flex-col gap-2">
                   <span className="text-sm text-slate-300">
@@ -154,4 +159,3 @@ export function Header() {
     </header>
   );
 }
-

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useTheme } from "@/contexts/ThemeContext";
+import { Palette, Sparkles } from "lucide-react";
+
+/**
+ * Compact pill that toggles between the default "studio" theme and the
+ * opt-in "aurora" theme. Renders the current theme name on >= sm screens
+ * and an icon-only button on mobile. The choice persists via the
+ * ThemeProvider (localStorage key "btc-pm-theme").
+ */
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const isAurora = theme === "aurora";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-pressed={isAurora}
+      aria-label={isAurora ? "Switch to Studio theme" : "Switch to Aurora theme"}
+      title={isAurora ? "Switch to Studio theme" : "Switch to Aurora theme"}
+      className="theme-toggle inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2"
+    >
+      {isAurora ? (
+        <Sparkles className="h-4 w-4 text-violet-300" />
+      ) : (
+        <Palette className="h-4 w-4 text-amber-300" />
+      )}
+      <span className="hidden sm:inline">{isAurora ? "Aurora" : "Studio"}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -42,3 +42,6 @@ export { useOnClickOutside } from "../hooks/useOnClickOutside";
 export { usePrevious } from "../hooks/usePrevious";
 export { useIntersectionObserver } from "../hooks/useIntersectionObserver";
 export { useBtcPrice } from "../hooks/useBtcPrice";
+export { useTheme } from "../hooks/useTheme";
+export { THEMES, THEME_STORAGE_KEY } from "../contexts/ThemeContext";
+export type { Theme } from "../contexts/ThemeContext";

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -31,6 +31,7 @@ export { Accordion } from "./Accordion";
 export { SearchInput } from "./SearchInput";
 export { MarketActivity } from "./MarketActivity";
 export { FavoriteButton } from "./FavoriteButton";
+export { ThemeToggle } from "./ThemeToggle";
 
 // Hooks
 export { useClipboard } from "../hooks/useClipboard";

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from "react";
+
+/**
+ * Theme options for the BTC Predict Studio frontend.
+ *
+ * - "studio": the default dark editorial look (unchanged from before).
+ * - "aurora": an opt-in sleeker variant with aurora gradients and
+ *   stronger micro-interactions, layered on top of the same design system.
+ *
+ * The active theme is mirrored onto <html data-theme="..."> so that the
+ * CSS variable overrides in globals.css take effect. The choice is
+ * persisted in localStorage and survives reloads. When no theme is
+ * stored (or storage is unavailable) we default to "studio", meaning the
+ * site looks exactly as it did before this feature shipped.
+ */
+
+export type Theme = "studio" | "aurora";
+
+export const THEME_STORAGE_KEY = "btc-pm-theme";
+export const THEMES: readonly Theme[] = ["studio", "aurora"];
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (next: Theme) => void;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function isTheme(value: string | null): value is Theme {
+  return value === "studio" || value === "aurora";
+}
+
+function readStoredTheme(): Theme {
+  if (typeof window === "undefined") return "studio";
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : "studio";
+  } catch {
+    return "studio";
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("studio");
+
+  // Hydrate from storage after mount.
+  useEffect(() => {
+    setThemeState(readStoredTheme());
+  }, []);
+
+  // Reflect the theme onto <html> as soon as we know it, before paint.
+  useLayoutEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    if (theme === "studio") {
+      // Default look: no overrides. Clear any previously set attribute
+      // so the base :root variables apply untouched.
+      delete root.dataset.theme;
+    } else {
+      root.dataset.theme = theme;
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // storage unavailable / quota — in-memory state still updates
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setThemeState((prev) => {
+      const next: Theme = prev === "studio" ? "aurora" : "studio";
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, setTheme, toggle }),
+    [theme, setTheme, toggle],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,4 @@
+"use client";
+
+export { useTheme, THEME_STORAGE_KEY, THEMES } from "@/contexts/ThemeContext";
+export type { Theme } from "@/contexts/ThemeContext";


### PR DESCRIPTION
## Summary

Adds an opt-in, persisted theming layer to the BTC Predict Studio frontend with a sleek new "Aurora" theme variant, **without distorting the existing site**. The default "Studio" look is byte-for-byte unchanged; Aurora is layered on via CSS variables on `<html data-theme="aurora">` and only activates when the user explicitly switches.

> **Note:** This branch is stacked on `chore/security-and-repo-hygiene` (#440), which fixes pre-existing broken merge-conflict markers in `globals.css` that this theme CSS appends to. Merge #440 first, then this one rebases cleanly onto `main`.

## What changed (5 commits)

1. **feat(theme): add ThemeProvider context with persisted theme switching** — new `contexts/ThemeContext.tsx` (`ThemeProvider` + `useTheme`), `hooks/useTheme.ts` re-export, wired into `app/providers.tsx`, plus a tiny no-flash inline `<head>` script in `layout.tsx` that applies a saved Aurora theme before first paint. Defaults to `studio` (data-theme removed, so only base `:root` vars apply).
2. **feat(theme): add Aurora sleek theme variant (CSS, opt-in)** — pure-CSS layer scoped under `[data-theme="aurora"]`: deeper violet-night tokens, animated aurora background wash, tinted selection/scrollbar/focus, card hover lift+glow, button sheen sweep, skeleton shimmer, and a `prefers-reduced-motion` block disabling all flourishes.
3. **feat(ui): add ThemeToggle control in the header** — new accessible `ThemeToggle` pill (Palette/Sparkles icons, `aria-pressed`/`aria-label`/`title`), rendered in both the desktop action row and the mobile nav menu; re-exported from the components barrel.
4. **feat(ui): add Aurora gradient headline, hero glow & eyebrow tint** — additional "cool theme" flourishes (gold→violet→sky gradient text on `.hero-panel h1`/`.section-title`, animated `aurora-glow` border on the hero, violet eyebrow tint), all opt-in and reduced-motion-aware.
5. **chore: gitignore TypeScript incremental build info files** — add `*.tsbuildinfo`.

## Does not distort the site

- The default experience is unchanged: `studio` clears `data-theme`, so only the original `:root` variables apply and no Aurora selectors match.
- All Aurora styles are scoped under `[data-theme="aurora"]`; they cannot leak into the default theme.
- No existing component markup was changed beyond adding `<ThemeToggle/>` (within existing flex gaps — no layout shift).
- All animations honor `prefers-reduced-motion`.

## Verification

- `tsc --noEmit`: **zero new errors** from any new/edited file (`ThemeContext`, `useTheme`, `ThemeToggle`, `Header`, `providers`, `layout`). The 12 reported errors are all **pre-existing on `main`** (AntiqueTooltip, BetModal, MarketCard, ParchmentHeader, WoodenButton, chart-processor, formatters) and out of scope.
- CSS brace balance verified (131/131). No conflict markers remain.
- `node -e require("./frontend/tailwind.config.js")` loads cleanly (fixed in #440).
- `next lint` is interactive-only here (ESLint not pre-configured in the repo) — pre-existing, not introduced by this PR.

## How to test

1. Run the frontend (`cd frontend && npm run dev`).
2. The site loads in the default Studio theme — identical to before.
3. Click the new theme toggle in the header → switches to Aurora (violet-night palette, animated aurora wash, gradient headline, card hover lift). Reload the page — the choice persists.
4. Click again to return to Studio.