### PR TITLE
fix(frontend): resolve pre-existing TypeScript build errors blocking Vercel deploy

### DIFF
--- a/frontend/src/components/AntiqueTooltip.tsx
+++ b/frontend/src/components/AntiqueTooltip.tsx
@@ -1,3 +1,3 @@
 
 /* implement AntiqueTooltip component */
-export const AntiqueTooltip = ({ text }) => <div className='bg-wood-dark text-paper text-xs p-1 rounded'>{text}</div>;
+export const AntiqueTooltip = ({ text }: { text: string }) => <div className='bg-wood-dark text-paper text-xs p-1 rounded'>{text}</div>;

--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -60,12 +60,12 @@ export function BetModal({ market, outcome, onClose }: BetModalProps) {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const parsedAmount = Number.parseFloat(amount || "0");
+  const minimumBet = MIN_BET_AMOUNT / 1_000_000;
   const validationMessage = parsedAmount > 0 && parsedAmount < minimumBet
     ? `Minimum bet is ${minimumBet} STX`
     : parsedAmount > 1000
       ? 'Maximum bet is 1,000 STX'
       : null;
-  const minimumBet = MIN_BET_AMOUNT / 1_000_000;
 
   const getOutcomePool = () => {
     switch (outcome) {

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -174,7 +174,7 @@ export function MarketCard({ market }: MarketCardProps) {
 
   return (
     <>
-      <div ref={cardRef} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave} className={`card card-tilt ${market.settled ? "opacity-85" : ""}`}>
+      <div className={`card ${market.settled ? "opacity-85" : ""}`}>
         <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/components/ParchmentHeader.tsx
+++ b/frontend/src/components/ParchmentHeader.tsx
@@ -1,3 +1,3 @@
 
 /* implement ParchmentHeader component */
-export const ParchmentHeader = ({ title }) => <h1 className='text-4xl text-wood-light border-b-2 border-wood-medium mb-4'>{title}</h1>;
+export const ParchmentHeader = ({ title }: { title: string }) => <h1 className='text-4xl text-wood-light border-b-2 border-wood-medium mb-4'>{title}</h1>;

--- a/frontend/src/components/WoodenButton.tsx
+++ b/frontend/src/components/WoodenButton.tsx
@@ -1,6 +1,6 @@
 
 /* create WoodenButton component */
-export const WoodenButton = ({ children }) => (
+export const WoodenButton = ({ children }: { children: React.ReactNode }) => (
   <button className='bg-wood-medium border-b-4 border-wood-dark px-4 py-2 rounded text-paper active:border-b-0 active:translate-y-1 transition-all'>
     {children}
   </button>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -51,6 +51,9 @@ export const CONTRACT_CAPABILITIES = {
 } as const;
 
 
+// Odds display format used by formatters and SDK utils.
+export type OddsFormat = "decimal" | "fractional" | "american";
+
 export const KEYBOARD_SHORTCUTS: Record<string, string> = {
   SEARCH: '/',
   CLOSE_MODAL: 'Escape',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary

The frontend `next build` was failing on `main` due to **12 pre-existing TypeScript errors** (present before the theme/hygiene PRs). These blocked **all** Vercel production deployments — every recent deploy (including Jun 26, before any of my PRs) failed. This PR fixes all of them so the site can deploy.

## Root cause

Vercel runs `next build`, which type-checks. The 12 errors were:
- `tsconfig.json` target `es5` → Map iterator spread fails (TS2802)
- `constants.ts` missing `OddsFormat` export that `formatters.ts` imports (TS2305)
- `BetModal.tsx` `minimumBet` used before declaration (TS2448/TS2454)
- `MarketCard.tsx` references to undefined `cardRef`/`handleMouseMove`/`handleMouseLeave` — leftover from a removed tilt effect (TS2304/TS2552)
- `AntiqueTooltip`/`ParchmentHeader`/`WoodenButton` implicit `any` prop types (TS7031)

## Fixes (7 files)

1. **tsconfig.json** — raise `target` from `es5` to `ES2017` (enables Map iterator spreading).
2. **constants.ts** — add `export type OddsFormat = "decimal" | "fractional" | "american"`.
3. **BetModal.tsx** — move `minimumBet` declaration above its first use.
4. **MarketCard.tsx** — remove undefined `ref`/`onMouseMove`/`onMouseLeave` refs and the no-op `card-tilt` class.
5. **AntiqueTooltip.tsx** — add `{ text: string }` prop type.
6. **ParchmentHeader.tsx** — add `{ title: string }` prop type.
7. **WoodenButton.tsx** — add `{ children: React.ReactNode }` prop type.

## Verification

- `tsc --noEmit`: **0 errors** (was 12).
- `next build`: **✓ Compiled successfully**, all 9 static pages generated.
- No behavioral changes — only type annotations, declaration ordering, dead-reference removal, and a compiler target bump.